### PR TITLE
Stop blacklisted entities being put into folders

### DIFF
--- a/com/bafomdad/realfilingcabinet/items/ItemEmptyFolder.java
+++ b/com/bafomdad/realfilingcabinet/items/ItemEmptyFolder.java
@@ -130,6 +130,11 @@ public class ItemEmptyFolder extends Item implements IEmptyFolder {
 		
 		if (!player.world.isRemote && stack.getItemDamage() == FolderType.MOB.ordinal()) {
 			if (!ConfigRFC.mobUpgrade) return false;
+			String entityblacklist = target.getClass().getSimpleName();
+			for (String toBlacklist : ConfigRFC.mobFolderBlacklist) {
+				if (toBlacklist.contains(entityblacklist))
+					return false;
+			}
 			
 			ItemStack newFolder = new ItemStack(RFCItems.folder, 1, 3);
 			if (ItemFolder.setObject(newFolder, target)) {


### PR DESCRIPTION
Currently, a blacklisted entity can be put into a mob folder. This is a problem as using the folder you can effectively reroll mobs random stats until you have the one you want.

In the case of the Mekanism Robit, stripping the NBT is even worse as it loses its owner tag and crashes the game.